### PR TITLE
Expose gotoDate method from fullCalendar

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject ajenda "0.1.9"
+(defproject ajenda "0.1.10"
   :description "A Reagent Wrapper for Full Calendar "
   :url "https://github.com/SVMBrown/ajenda"
   :license {:name "MIT"

--- a/src/cljs/ajenda/core.cljs
+++ b/src/cljs/ajenda/core.cljs
@@ -133,4 +133,10 @@
                                (-> this $ (.fullCalendar "render")))
      :component-will-unmount (fn [this]
                                (-> this $ (.fullCalendar "destroy")))
-     :reagent-render         (fn [_] [:div.calendar])}))
+     :reagent-render         (fn [_] [:div#myFullCalendar.calendar])}))
+
+;; fullCalendar methods
+(defn fc-go-to-date [date]
+  "Calls fullCalendar gotoDate method expecting date in yyyy-mm-dd form."
+  (let [calendar (js/$ "#myFullCalendar")]
+    (.fullCalendar calendar "gotoDate" date)))


### PR DESCRIPTION
@yogthos Exposed `gotoDate` method from fullCalendar for the purpose of changing the date (e.g. date filtering) via an external event. Added an `id` to the full calendar element so it can be accessed using jQuery but, there is probably a better way to achieve the same thing.