### PR TITLE
Add # to the calendar-id before jQuerying. Update docstring position.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject ajenda "0.1.10"
+(defproject ajenda "0.1.11"
   :description "A Reagent Wrapper for Full Calendar "
   :url "https://github.com/SVMBrown/ajenda"
   :license {:name "MIT"

--- a/src/cljc/ajenda/util.cljc
+++ b/src/cljc/ajenda/util.cljc
@@ -2,7 +2,8 @@
 
 #?(:cljs
 
-   (defn go-to-date [calendar-id date]
+   (defn go-to-date
      "Calls fullCalendar gotoDate method expecting date in yyyy-mm-dd form."
-     (let [calendar (js/$ calendar-id)]
+     [calendar-id date]
+     (let [calendar (js/$ (str "#" calendar-id))]
        (.fullCalendar calendar "gotoDate" date))))


### PR DESCRIPTION
@yogthos A fix, assuming that the value of the `:id` key specified in the Calendar `opts` map is a string which doesn't begin with a `#`, then we would need to prepend `#` before using jQuery to find the node.